### PR TITLE
Add programming language as requirement for Nand To Tetris Part II

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ for how to progress through the course.
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
 [Build a Modern Computer from First Principles: From Nand to Tetris](https://www.coursera.org/learn/build-a-computer) ([alt](http://www.nand2tetris.org/)) | 6 weeks | 7-13 hours/week | none
-[Build a Modern Computer from First Principles: Nand to Tetris Part II ](https://www.coursera.org/learn/nand2tetris2) | 6 weeks | 12-18 hours/week | any programming language, From Nand to Tetris Part I
+[Build a Modern Computer from First Principles: Nand to Tetris Part II ](https://www.coursera.org/learn/nand2tetris2) | 6 weeks | 12-18 hours/week | one of [these programming languages](https://user-images.githubusercontent.com/2046800/35426340-f6ce6358-026a-11e8-8bbb-4e95ac36b1d7.png), From Nand to Tetris Part I
 [Introduction to Computer Networking](https://lagunita.stanford.edu/courses/Engineering/Networking-SP/SelfPaced/about)| 8 weeks | 4–12 hours/week | algebra, probability, basic CS
 [ops-class.org - Hack the Kernel](https://www.ops-class.org/) | 15 weeks | 6 hours/week | algorithms
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ for how to progress through the course.
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
 [Build a Modern Computer from First Principles: From Nand to Tetris](https://www.coursera.org/learn/build-a-computer) ([alt](http://www.nand2tetris.org/)) | 6 weeks | 7-13 hours/week | none
-[Build a Modern Computer from First Principles: Nand to Tetris Part II ](https://www.coursera.org/learn/nand2tetris2) | 6 weeks | 12-18 hours/week | From Nand to Tetris Part I, Java or Python
+[Build a Modern Computer from First Principles: Nand to Tetris Part II ](https://www.coursera.org/learn/nand2tetris2) | 6 weeks | 12-18 hours/week | any programming language, From Nand to Tetris Part I
 [Introduction to Computer Networking](https://lagunita.stanford.edu/courses/Engineering/Networking-SP/SelfPaced/about)| 8 weeks | 4–12 hours/week | algebra, probability, basic CS
 [ops-class.org - Hack the Kernel](https://www.ops-class.org/) | 15 weeks | 6 hours/week | algorithms
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ for how to progress through the course.
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
 [Build a Modern Computer from First Principles: From Nand to Tetris](https://www.coursera.org/learn/build-a-computer) ([alt](http://www.nand2tetris.org/)) | 6 weeks | 7-13 hours/week | none
-[Build a Modern Computer from First Principles: Nand to Tetris Part II ](https://www.coursera.org/learn/nand2tetris2) | 6 weeks | 12-18 hours/week | From Nand to Tetris Part I
+[Build a Modern Computer from First Principles: Nand to Tetris Part II ](https://www.coursera.org/learn/nand2tetris2) | 6 weeks | 12-18 hours/week | From Nand to Tetris Part I, Java or Python
 [Introduction to Computer Networking](https://lagunita.stanford.edu/courses/Engineering/Networking-SP/SelfPaced/about)| 8 weeks | 4–12 hours/week | algebra, probability, basic CS
 [ops-class.org - Hack the Kernel](https://www.ops-class.org/) | 15 weeks | 6 hours/week | algorithms
 


### PR DESCRIPTION
One of these two programming languages are required to complete the course assignments, most of which ask students to write programs to parse/compile the Jack language into VM code, or translate VM code into machine language.

The requirement is stated in the video lecture "[Week 1 > Course Overview > Course Overview (20 min)](https://www.coursera.org/learn/nand2tetris2/lecture/jEmbG/course-overview)" at 17:06:

"We expect that you have some programming ability, st the level which is acquired in typical Introduction to Computer Science courses. **So you have to know either Java or Python**. You have to know the basic techniques and skills of object-oriented programming. If you have this basic knowledge, then you're welcome to take Nand to Tetris Part II. It is also recommended, but certainly not required, that you will take Nand to Tetris Part I. In fact, the two courses are so independent of each other that you can take them in reverse order, if you will. But of course we recommend that you take part one first, part two second. But once again, you don't have to. You can start from scratch with the Nand to Tetris Part II."
