### PR TITLE
Remove dead link to Facebook group

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ These aren't the only specializations you can choose. Check the following websit
 - Use our [forum](https://github.com/ossu/forum) if you need some help.
 - You can also interact through [GitHub issues](https://github.com/ossu/computer-science/issues).
 - We also have a chat room! [![Join the chat at https://gitter.im/open-source-society/computer-science](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/open-source-society/computer-science?utm_campaign=pr-badge&utm_content=badge&utm_medium=badge&utm_source=badge)
-- Add **Open Source Society University** to your [Linkedin](https://www.linkedin.com/school/11272443/) and [Facebook](https://www.facebook.com/ossuniversity) profile!
+- Add **Open Source Society University** to your [Linkedin](https://www.linkedin.com/school/11272443/) profile!
 
 > **PS**: A forum is an ideal way to interact with other students as we do not lose important discussions, which usually occur in communication via chat apps.
 **Please use our forum for important discussions**.


### PR DESCRIPTION
The link to the Facebook group resolves to a page stating:
_Sorry, this content isn't available right now
The link you followed may have expired, or the page may only be visible to an audience you're not in._

Linked resources should be available to all students. Links to deprecated discussion forums should be deleted.