### PR TITLE
Add PBRT (now free) to readings section

### DIFF
--- a/extras/readings.md
+++ b/extras/readings.md
@@ -76,3 +76,4 @@ Name | Author(s)
 [Compilers: Principles, Techniques, and Tools (2nd Edition)](http://www.amazon.com/Compilers-Principles-Techniques-Tools-2nd/dp/0321486811/) | Alfred V. Aho, Monica S. Lam, Ravi Sethi,  Jeffrey D. Ullman
 [Compiler Construction](http://www.ethoberon.ethz.ch/WirthPubl/CBEAll.pdf) | Niklaus Wirth 
 [The Mythical Man-Month](https://www.amazon.com/Mythical-Man-Month-Software-Engineering-Anniversary/dp/0201835959/) | Fred Brooks, Jr.
+[Physically Based Rendering: From Theory To Implementation](http://www.pbr-book.org/) | Matt Pharr, Wenzel Jakob, and Greg Humphreys


### PR DESCRIPTION
PBRT is an amazing book detailing the implementation of a real, well-developed path tracer and is used in many real Computer Graphics courses. The authors have no released it for free, so I think it would make a great addition to the curriculum.