### PR TITLE
Add curricular guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ These aren't the only specializations you can choose. Check the following websit
 - Use our [forum](https://github.com/ossu/forum) if you need some help.
 - You can also interact through [GitHub issues](https://github.com/ossu/computer-science/issues).
 - We also have a chat room! [![Join the chat at https://gitter.im/open-source-society/computer-science](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/open-source-society/computer-science?utm_campaign=pr-badge&utm_content=badge&utm_medium=badge&utm_source=badge)
-- Add **Open Source Society University** to your [Linkedin](https://www.linkedin.com/school/11272443/) and [Facebook](https://www.facebook.com/ossuniversity) profile!
+- Add **Open Source Society University** to your [Linkedin](https://www.linkedin.com/school/11272443/) profile!
 
 > **PS**: A forum is an ideal way to interact with other students as we do not lose important discussions, which usually occur in communication via chat apps.
 **Please use our forum for important discussions**.

--- a/extras/curriculum_guidelines.md
+++ b/extras/curriculum_guidelines.md
@@ -1,0 +1,23 @@
+# Computer Science - Curricular Resources
+
+## Accreditation Board for Engineering and Technology
+
+ABET, incorporated as the Accreditation Board for Engineering and Technology, Inc., is a non-governmental organization that accredits post-secondary education programs in applied and natural science, computing, engineering and engineering technology. As of October 2017, 3,852 programs are accredited, distributed over 776 universities and colleges in 31 countries. ABET is the recognized U.S. accreditor of college and university programs in applied and natural science, computing, engineering and engineering technology.
+
+[Program Criteria for Computer Science, Information Systems, and Information Technology Programs](http://www.abet.org/accreditation/accreditation-criteria/criteria-for-accrediting-computing-programs-2018-2019/#2)
+
+## The Association for Computing Machinery
+
+The Association for Computing Machinery (ACM) is an international learned society for computing. It was founded in 1947, and is the world's largest scientific and educational computing society. The ACM is a non-profit professional membership group, with more than 100,000 members as of 2011.
+
+### with
+
+## Institute of Electrical and Electronics Engineers
+
+The Institute of Electrical and Electronics Engineers (IEEE) is a professional association formed in 1963 from the amalgamation of the American Institute of Electrical Engineers and the Institute of Radio Engineers. As of 2018, it is the world's largest association of technical professionals with more than 423,000 members in over 160 countries around the world. Its objectives are the educational and technical advancement of electrical and electronic engineering, telecommunications, computer engineering and allied disciplines.
+
+[Curriculum Guidelines for Undergraduate Programs in Computer Science](https://www.acm.org/binaries/content/assets/education/cs2013_web_final.pdf)
+
+[Curriculum Guidelines for Undergraduate Degree Programs in Software Engineering](https://www.acm.org/binaries/content/assets/education/se2014.pdf)
+
+[Computer Engineering Curricula](https://www.acm.org/binaries/content/assets/education/ce2016-final-report.pdf)


### PR DESCRIPTION
Our Extras page should reference high quality curricular guidance. Currently one such source is mentioned in an issue. Moving this to Extras makes it a permanent part of the curriculum, in a place that learners can interact with it.

https://github.com/ossu/computer-science/issues/482