### PR TITLE
README: Propose GTx CS1301 as an alternate introduction course

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
 [Introduction to Computer Science and Programming using Python](https://www.edx.org/course/introduction-computer-science-mitx-6-00-1x-10) | 9 weeks | 15 hours/week | high school algebra
 
+Alternatively, complete the entire four-part course below.
+
+Courses | Duration | Effort | Prerequisites
+:-- | :--: | :--: | :--:
+[Computing In Python, Part I: Fundamentals and Procedural Programming](https://www.edx.org/course/computing-in-python-i-fundamentals-and-procedural-programming-0) | 5 weeks | 10 hours/week | high school algebra
+[Computing In Python, Part II: Control Structures](https://www.edx.org/course/computing-in-python-ii-control-structures-0) | 5 weeks | 10 hours/week | Computing In Python, Part I
+[Computing In Python, Part III: Data Structures](https://www.edx.org/course/computing-in-python-iii-data-structures-0) | 5 weeks | 10 hours/week | Computing In Python, Part II
+[Computing In Python, Part IV: Objects & Algorithms](https://www.edx.org/course/computing-in-python-iv-objects-algorithms-0) | 5 weeks | 10 hours/week | Computing In Python, Part III
+
 ## Core CS
 
 All coursework under Core CS is **required**, unless otherwise indicated.


### PR DESCRIPTION
I propose using Georgia Tech's CS1301 (Computing In Python) course as an alternate introduction course, either in lieu of MITx 6.00.1x, or sequenced before 6.00.1x.

Georgia Tech's CS1301x course is an adaptation of a 16-week on-campus course which first became available on EdX in July 2018, and is offered as a four-part sequence leading to an optional Professional Certificate. Completing this course provides an equivalent background to MIT's 6.00.1x course, but provides more instruction and extensive practice in Python coding, with over 300 short coding problems to help build confidence and muscle memory in a short period of time.

This course also provides access to a free "adaptive textbook" which tests one's understanding of the material. A non-adaptive PDF copy is made available for offline reading.

Having taken both courses, in my opinion MITx 6.00.1x provides an excellent introduction to computer science concepts but expects the user to pick up Python more or less on his own. GTx CS1301 serves as a gentler introduction, teaching the same concepts but also taking time to teach Python along the way. This may be a more attractive option for true beginners, many of which find 6.00.1x to be too much all at once.