### PR TITLE
Fix Introduction to Parallel Programming link

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Courses | Duration | Effort | Prerequisites
 [Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming
 [Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience
 [LAFF - On Programming for Correctness](https://www.edx.org/course/laff-on-programming-for-correctness) | 7 weeks | 6 hours/week | linear algebra
-[Introduction to Parallel Programming](https://www.udacity.com/course/intro-to-parallel-programming--cs344) ([alt](https://www.youtube.com/playlist?list=PLGvfHSgImk4aweyWlhBXNF6XISY3um82_)) | 12 weeks | - | C, algorithms
+[Introduction to Parallel Programming](https://developer.nvidia.com/udacity-cs344-intro-parallel-programming) ([alt](https://www.youtube.com/playlist?list=PLGvfHSgImk4aweyWlhBXNF6XISY3um82_)) | 12 weeks | - | C, algorithms
 [Software Architecture & Design](https://www.udacity.com/course/software-architecture-design--ud821)| 8 weeks | 6 hours/week | software engineering in Java
 
 ### Advanced math


### PR DESCRIPTION
This PR changes the Introduction to Parallel Programming link from https://www.udacity.com/course/intro-to-parallel-programming--cs344 to https://developer.nvidia.com/udacity-cs344-intro-parallel-programming . The old link no longer works. The new link points to the same course except it is hosted on nvidia's website.