### PR TITLE
 extras/readings: update links

### DIFF
--- a/extras/readings.md
+++ b/extras/readings.md
@@ -11,9 +11,9 @@ Or, if you are struggling in one of the courses, perhaps reading a book on the s
 
 Name | Author(s)
 :-- | :--:
-[Introduction to Computation and Programming Using Python](https://www.amazon.com/Introduction-Computation-Programming-Using-Python/dp/0262525003/) | John V. Guttag
+[Introduction to Computation and Programming Using Python 2e](https://www.amazon.com/Introduction-Computation-Programming-Using-Python-ebook/dp/B00H4D1W9E/) | John V. Guttag
 [Think Python 2e](http://greenteapress.com/wp/think-python-2e/) | Allen B. Downey
-[How to Design Programs](http://www.ccs.neu.edu/home/matthias/HtDP2e/) | Matthias Felleisen, Robert Bruce Findler, Matthew Flatt, Shriram Krishnamurthi
+[How to Design Programs](https://www.htdp.org/) | Matthias Felleisen, Robert Bruce Findler, Matthew Flatt, Shriram Krishnamurthi
 [Structure and Interpretation of Computer Programs](https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book.html) | Hal Abelson, Jerry Sussman, Julie Sussman 
 [Concepts, Techniques, and Models of Computer Programming](https://www.amazon.com/gp/product/0262220695) | Peter Van Roy, Seif Haridi
 [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612) | Erich Gamma, Richard Helm, Ralph Johnson, John Vlissides

--- a/extras/readings.md
+++ b/extras/readings.md
@@ -11,7 +11,7 @@ Or, if you are struggling in one of the courses, perhaps reading a book on the s
 
 Name | Author(s)
 :-- | :--:
-[Introduction to Computation and Programming Using Python 2e](https://www.amazon.com/Introduction-Computation-Programming-Using-Python-ebook/dp/B00H4D1W9E/) | John V. Guttag
+[Introduction to Computation and Programming Using Python 2e](https://www.amazon.com/Introduction-Computation-Programming-Using-Python-dp-0262525003/dp/0262525003/) | John V. Guttag
 [Think Python 2e](http://greenteapress.com/wp/think-python-2e/) | Allen B. Downey
 [How to Design Programs](https://www.htdp.org/) | Matthias Felleisen, Robert Bruce Findler, Matthew Flatt, Shriram Krishnamurthi
 [Structure and Interpretation of Computer Programs](https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book.html) | Hal Abelson, Jerry Sussman, Julie Sussman 


### PR DESCRIPTION
Correcting the htdp link and updating Introduction to Computation and Programming Using Python to the newer version which switches to Python 3.