### PR TITLE
Updated Game Theory stats to reflect Coursera

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Courses | Duration | Effort | Prerequisites
 [Automata Theory](https://lagunita.stanford.edu/courses/course-v1:ComputerScience+Automata+SelfPaced/about) | 7 weeks | 10 hours/week | discrete mathematics, logic, algorithms
 [Computational Geometry](https://www.edx.org/course/computational-geometry-tsinghuax-70240183x) | 16 weeks | 8 hours/week | algorithms, C++
 [Introduction to Formal Concept Analysis](https://www.coursera.org/learn/formal-concept-analysis) | 6 weeks | 4-6 hours/week | logic, probability
-[Game Theory](https://www.coursera.org/learn/game-theory-1) | 8 weeks | x hours/week | mathematical thinking, probability, calculus
+[Game Theory](https://www.coursera.org/learn/game-theory-1) | 4 weeks | 5 hours/week | mathematical thinking, probability, calculus
 
 ### Advanced applications
 


### PR DESCRIPTION
I noticed some inconsistencies between the commitment hours here and what is reported on the actual course site: https://www.coursera.org/learn/game-theory-1

Was there a reason it said 8 weeks at x hours? 