### PR TITLE
Removes extra column in table core theory

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Courses | Duration | Effort | Additional Text / Assignments| Prerequisites
 `and more`
 
 Courses | Duration | Prerequisites
-:-- | :--: | :--: | :--:
+:-- | :--: | :--:
 [Algorithms](https://www.coursera.org/specializations/algorithms) | 80 hours | any programming language, Mathematics for Computer Science
 
 


### PR DESCRIPTION
Table core theory was not rendering correctly due to an extra column (see image). This fixes the issue. 

![image](https://user-images.githubusercontent.com/7271727/74823202-c7d5f180-531f-11ea-9aeb-99875b0ccaae.png)
