### PR TITLE
Add Gitter link to Getting help in Summary section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ just remember that you can't purchase success!
 
 **How to contribute**. Please see [CONTRIBUTING](CONTRIBUTING.md).
 
-**Getting help**. Please check our [Frequently Asked Questions](FAQ.md), and if you cannot find the answer, file an issue or talk to our [friendly community](#community)!
+**Getting help**. Please check our [Frequently Asked Questions](FAQ.md), and if you cannot find the answer, file an issue or talk to our [friendly community](#community)! In particular, join in the conversation on our [Gitter](https://gitter.im/open-source-society/computer-science) (which is an online chat service, similar to Discord or IRC) where you can chat with other students and get help. [![Join the chat at https://gitter.im/open-source-society/computer-science](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/open-source-society/computer-science?utm_campaign=pr-badge&utm_content=badge&utm_medium=badge&utm_source=badge)
 
 # Curriculum
 


### PR DESCRIPTION
Rationale: A new student probably does not know what Git, GitHub or Gitter are, so explaining what it is and putting it near the top of the page in the summary section will help guide people to the Gitter more easily.

I would not be averse to adding it into the Introduction section too. It is easy to skim over and the introduction phase is when students probably most need a little help.