### PR TITLE
Add Computer Architecture/Organization courses

### DIFF
--- a/extras/courses.md
+++ b/extras/courses.md
@@ -40,6 +40,8 @@ Courses | Duration | Effort
 Courses | Duration | Effort
 :-- | :--: | :--:
 [Cloud Computing / Distributed Programming](https://www.coursera.org/learn/cloud-computing) | 5 weeks | 5-10 hours/week
+[Intro to Computer Systems](http://www.cs.cmu.edu/afs/cs.cmu.edu/academic/class/15213-f15/www/) ([Labs](http://csapp.cs.cmu.edu/3e/labs.html)) | 15 weeks | 12 hours/week
+[Great Ideas in Computer Architecture (Machine Structures)](https://inst.eecs.berkeley.edu/~cs61c/fa14/) ([Lectures](https://archive.org/details/ucberkeley_webcast_itunesu_915550404)) | 15 weeks | 12 hours/week
 [Computer Architecture](https://www.coursera.org/learn/comparch) | - | 5-8 hours/week
 [Operating System Engineering](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-828-operating-system-engineering-fall-2012/) | - | -
 [Introduction to Operating Systems](https://www.udacity.com/course/introduction-to-operating-systems--ud923)| 8 weeks | 5-8 hours/week


### PR DESCRIPTION
Prerequisite for both is CS1-2. Either course (Berkeley and Carnegie Mellon) is suitable as an alternative to nand2tetris and/or 6.004 as the required course of choice for Computer Architecture/Organization. The Princeton course that's already here would have one of these 4 courses as a prerequisite and is suitable as an elective.