### PR TITLE
Added link to HW for Intro to Parallel Programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ If not, or if a student chooses not to take the Capstone, then a separate Final 
 
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
-[Introduction to Parallel Programming](https://classroom.udacity.com/courses/cs344) ([alt](https://www.youtube.com/playlist?list=PLGvfHSgImk4aweyWlhBXNF6XISY3um82_)) | 12 weeks | - | C, algorithms
+[Introduction to Parallel Programming](https://classroom.udacity.com/courses/cs344) ([alt](https://www.youtube.com/playlist?list=PLGvfHSgImk4aweyWlhBXNF6XISY3um82_)) ([HW](https://colab.research.google.com/github/depctg/udacity-cs344-colab))| 12 weeks | - | C, algorithms
 [Compilers](https://www.edx.org/course/compilers) ([alt](https://www.youtube.com/playlist?list=PLDcmCgguL9rxPoVn2ykUFc8TOpLyDU5gx))| 9 weeks | 6-8 hours/week | none
 [Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming
 [Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience


### PR DESCRIPTION
Intro to Parallel Programming's grader is broken (returns garbled nonsense output), it's impossible to submit programming assignments. It's also impossible to compile and run the code on your PC, unless you own an nVidia GPU. Thankfully some nice folks on Github created a Google Research Colab page where you can compile and run your homeworks (unfortunately the Final Exam is not available and probably never will be). I understand this uses Google's GPU sharing.