### PR TITLE
Add Probability alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Courses | Duration | Effort | Prerequisites
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
 [Introduction to Probability - The Science of Uncertainty](https://www.edx.org/course/introduction-probability-science-mitx-6-041x-2) | 18 weeks | 12 hours/week | [Multivariable Calculus](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/index.htm)
+[Alternative: Harvard Stats110](https://projects.iq.harvard.edu/stat110/home) | 18 weeks | 12 hours/week | [Multivariable Calculus](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/)
 
 ### Core Math
 In addition to their math elective, students must complete the following course on discrete mathematics.


### PR DESCRIPTION
Added an alternative Probability course. It covers the **same content** as the existing one. Some would say that this one is better, the only reason I would recommend this one is that it has a full version outside of EdX, so learners can take their time to understand material if they choose not to pay. This one has many exercices for practice. It also has an EdX version, I tried it and didn't like it that much. **Optional book** _not realted to this course_ but it covers everything literally step-by-step (it saved me in combinatronics): https://www.goodreads.com/en/book/show/29991429-probability