### PR TITLE
Replace Probability course

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Courses | Duration | Effort | Prerequisites
 #### Probability
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
-[Harvard Stats110](https://projects.iq.harvard.edu/stat110/home) | 24 weeks | 12 hours/week | [Multivariable Calculus](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/)
+[Harvard Stat110](https://projects.iq.harvard.edu/stat110/home) | 24 weeks | 12 hours/week | [Multivariable Calculus](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/)
 
 ### Core Math
 In addition to their math elective, students must complete the following course on discrete mathematics.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Courses | Duration | Effort | Prerequisites
 #### Probability
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
-[Introduction to Probability - The Science of Uncertainty](https://www.edx.org/course/introduction-probability-science-mitx-6-041x-2) | 18 weeks | 12 hours/week | [Multivariable Calculus](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/index.htm)
+[Harvard Stats110](https://projects.iq.harvard.edu/stat110/home) | 24 weeks | 12 hours/week | [Multivariable Calculus](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/)
 
 ### Core Math
 In addition to their math elective, students must complete the following course on discrete mathematics.

--- a/extras/courses.md
+++ b/extras/courses.md
@@ -35,6 +35,7 @@ Courses | Duration | Effort
 [Introduction to Probability and Data](https://www.coursera.org/learn/probability-intro)| - | -
 [Linear Algebra (Strang)](https://ocw.mit.edu/courses/mathematics/18-06-linear-algebra-spring-2010/index.htm) | - | -
 [Multivariable Calculus](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/index.htm) | 13 weeks | 12 hours/week
+[Introduction to Probability - The Science of Uncertainty](https://www.edx.org/course/introduction-probability-science-mitx-6-041x-2) | 18 weeks | 12 hours/week | [Multivariable Calculus](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/index.htm)
 
 ## Systems
 


### PR DESCRIPTION
**Added Harvard's Stat110** Probability course to curriculum (README.md) and **moved old one** to the extra courses file (extras/courses.md)