### PR TITLE
Changed Py4E hours of effort to match OSSU expected weekly effort levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ and is knowledgeable enough now to decide which electives to take.
 
 ### Introduction to Programming
 
-If you've never written a for-loop, or don't know what a string is in programming, start here.
+If you've never written a for-loop, or don't know what a string is in programming, start here. This course is self-paced, allowing you to adjust the number of hours you spend per week to meet your needs.
 
 **Topics covered**:
 `simple programs`
@@ -125,7 +125,7 @@ If you've never written a for-loop, or don't know what a string is in programmin
 
 Courses | Duration | Effort | Prerequisites | Discussion
 :-- | :--: | :--: | :--: | :--:
-[Python for Everybody](https://www.py4e.com/) | 34 weeks | 3 hours/week | none | [chat](https://discord.gg/syA242Z)
+[Python for Everybody](https://www.py4e.com/) | 10 weeks | 10 hours/week | none | [chat](https://discord.gg/syA242Z)
 
 ### Introduction to Computer Science
 


### PR DESCRIPTION
A frequent complaint of our introductory course Python For Everyone (Py4E) is that our projected level of effort claims it takes 34 weeks to complete this course. There has been recent discussion indicating that an 8-month introductory course may be too ambitious for the OSSU program (including on the Discord channel and #785.) Meanwhile, many students on the Discord report being able to complete Py4E in substantially shorter time periods by increasing the amount of effort.

The 34 week course duration is estimated from an assumed 3 hours of effort per week. Other courses in the OSSU program assume 8-12 hours of effort per week. 

**Problem:** Assigning 3 hours of effort per week for our Py4E course is artificially inflating the perceived length of the course.

**Complication:** The course is truly self-paced, and progress can be made with as little as 3 hours of effort per week - should the student so choose.

**Proposed Solution:** Adjust the advertised level of effort to a nominal 10 weeks at a nominal 10 hours of effort per week, to put this course on parity with the introductory courses that follow it. Provide additional notation to clarify that the course is self-paced and the required level of effort can be adjusted to meet the student's needs.