### PR TITLE
updated Prolog link, added PDF version (fixes #868)

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,12 +348,12 @@ Courses | Duration | Effort | Prerequisites
 [Parallel Programming](https://www.coursera.org/learn/parprog1)| 4 weeks | 6-8 hours/week | Scala programming
 [Compilers](https://www.edx.org/course/compilers) | 9 weeks | 6-8 hours/week | none
 [Introduction to Haskell](https://www.seas.upenn.edu/~cis194/fall16/)| 14 weeks | - | -
-[Learn Prolog Now!](https://www.let.rug.nl/bos/lpn//lpnpage.php?pageid=online) [(alt)*](https://github.com/ossu/computer-science/files/6085884/lpn.pdf)| 12 weeks | - | -
+[Learn Prolog Now!](https://www.let.rug.nl/bos/lpn//lpnpage.php?pageid=online) ([alt](https://github.com/ossu/computer-science/files/6085884/lpn.pdf))*| 12 weeks | - | -
 [Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming
 [Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience
 [Software Architecture & Design](https://www.udacity.com/course/software-architecture-design--ud821)| 8 weeks | 6 hours/week | software engineering in Java
 
-(*) book by Blackburn, Bos, Striegnitz (compiled from source, redistributed under [CC license](http://creativecommons.org/licenses/by-sa/4.0/))
+(*) book by Blackburn, Bos, Striegnitz (compiled from [source](https://github.com/LearnPrologNow/lpn), redistributed under [CC license](http://creativecommons.org/licenses/by-sa/4.0/))
 
 ### Advanced systems
 

--- a/README.md
+++ b/README.md
@@ -343,15 +343,15 @@ If not, or if a student chooses not to take the Capstone, then a separate Final 
 `large-scale software architecture and design`
 `and more`
 
-Courses | Duration | Effort | Prerequisites
-:-- | :--: | :--: | :--:
-[Parallel Programming](https://www.coursera.org/learn/parprog1)| 4 weeks | 6-8 hours/week | Scala programming
-[Compilers](https://www.edx.org/course/compilers) | 9 weeks | 6-8 hours/week | none
-[Introduction to Haskell](https://www.seas.upenn.edu/~cis194/fall16/)| 14 weeks | - | -
-[Learn Prolog Now!](http://www.learnprolognow.org/lpnpage.php?pageid=online)| 12 weeks | - | -
-[Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming
-[Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience
-[Software Architecture & Design](https://www.udacity.com/course/software-architecture-design--ud821)| 8 weeks | 6 hours/week | software engineering in Java
+Courses | Duration | Effort | Prerequisites| Text 
+:-- | :--: | :--: | :--: | ---- 
+[Parallel Programming](https://www.coursera.org/learn/parprog1)| 4 weeks | 6-8 hours/week | Scala programming| 
+[Compilers](https://www.edx.org/course/compilers) | 9 weeks | 6-8 hours/week | none| 
+[Introduction to Haskell](https://www.seas.upenn.edu/~cis194/fall16/)| 14 weeks | - | -| 
+[Learn Prolog Now!](https://www.let.rug.nl/bos/lpn//lpnpage.php?pageid=online)| 12 weeks | - | -| [book version](https://github.com/ossu/computer-science/files/6085884/lpn.pdf) by Blackburn, Bos, Striegnitz (redistributed under [CC license](http://creativecommons.org/licenses/by-sa/4.0/)) 
+[Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming| 
+[Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience| 
+[Software Architecture & Design](https://www.udacity.com/course/software-architecture-design--ud821)| 8 weeks | 6 hours/week | software engineering in Java| 
 
 ### Advanced systems
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Courses | Duration | Effort | Prerequisites
 [Parallel Programming](https://www.coursera.org/learn/parprog1)| 4 weeks | 6-8 hours/week | Scala programming
 [Compilers](https://www.edx.org/course/compilers) | 9 weeks | 6-8 hours/week | none
 [Introduction to Haskell](https://www.seas.upenn.edu/~cis194/fall16/)| 14 weeks | - | -
-[Learn Prolog Now!](https://www.let.rug.nl/bos/lpn//lpnpage.php?pageid=online) [alt](https://github.com/ossu/computer-science/files/6085884/lpn.pdf) (*)| 12 weeks | - | -
+[Learn Prolog Now!](https://www.let.rug.nl/bos/lpn//lpnpage.php?pageid=online) [(alt)*](https://github.com/ossu/computer-science/files/6085884/lpn.pdf)| 12 weeks | - | -
 [Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming
 [Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience
 [Software Architecture & Design](https://www.udacity.com/course/software-architecture-design--ud821)| 8 weeks | 6 hours/week | software engineering in Java

--- a/README.md
+++ b/README.md
@@ -343,15 +343,17 @@ If not, or if a student chooses not to take the Capstone, then a separate Final 
 `large-scale software architecture and design`
 `and more`
 
-Courses | Duration | Effort | Prerequisites| Text 
-:-- | :--: | :--: | :--: | ---- 
-[Parallel Programming](https://www.coursera.org/learn/parprog1)| 4 weeks | 6-8 hours/week | Scala programming| 
-[Compilers](https://www.edx.org/course/compilers) | 9 weeks | 6-8 hours/week | none| 
-[Introduction to Haskell](https://www.seas.upenn.edu/~cis194/fall16/)| 14 weeks | - | -| 
-[Learn Prolog Now!](https://www.let.rug.nl/bos/lpn//lpnpage.php?pageid=online)| 12 weeks | - | -| [book version](https://github.com/ossu/computer-science/files/6085884/lpn.pdf) by Blackburn, Bos, Striegnitz (redistributed under [CC license](http://creativecommons.org/licenses/by-sa/4.0/)) 
-[Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming| 
-[Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience| 
-[Software Architecture & Design](https://www.udacity.com/course/software-architecture-design--ud821)| 8 weeks | 6 hours/week | software engineering in Java| 
+Courses | Duration | Effort | Prerequisites
+:-- | :--: | :--: | :--: 
+[Parallel Programming](https://www.coursera.org/learn/parprog1)| 4 weeks | 6-8 hours/week | Scala programming
+[Compilers](https://www.edx.org/course/compilers) | 9 weeks | 6-8 hours/week | none
+[Introduction to Haskell](https://www.seas.upenn.edu/~cis194/fall16/)| 14 weeks | - | -
+[Learn Prolog Now!](https://www.let.rug.nl/bos/lpn//lpnpage.php?pageid=online) [alt](https://github.com/ossu/computer-science/files/6085884/lpn.pdf) (*)| 12 weeks | - | -
+[Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming
+[Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience
+[Software Architecture & Design](https://www.udacity.com/course/software-architecture-design--ud821)| 8 weeks | 6 hours/week | software engineering in Java
+
+(*) book by Blackburn, Bos, Striegnitz (compiled from source, redistributed under [CC license](http://creativecommons.org/licenses/by-sa/4.0/))
 
 ### Advanced systems
 


### PR DESCRIPTION
@waciumawanjohi See #868 for the discussion.

The Prolog link went dead again for a few days, like it did a few months ago.
It came back but it seems to have changed hosts. Updated the link.
The individual linked pages were missing but now they seem to be fully back.

@Saif-XI-Coderz pointed me to the [source code](https://github.com/LearnPrologNow/lpn) 
I was able to compile the LaTeX source into a PDF textbook which is freely redistributable under Creative Commons 4.0.
So I thought if this happens again people can have the PDF instead.
The contents of the web version and the PDF are identical as far as I can tell.

It's not necessary to merge this. The [current link](http://www.learnprolognow.org/lpnpage.php?pageid=online) correctly redirects to the [new page](https://www.let.rug.nl/bos/lpn//lpnpage.php?pageid=online) but who knows what will happen later.

What do you think? Merge if you think it's a good idea.
