### PR TITLE
Add Full Stack Open course

### DIFF
--- a/extras/courses.md
+++ b/extras/courses.md
@@ -80,6 +80,7 @@ Courses | Duration | Effort
 [Intro to Machine Learning](https://www.udacity.com/course/intro-to-machine-learning--ud120)| 10 weeks | 6-10 hours/week
 [Machine Learning for Data Science and Analytics](https://www.edx.org/course/machine-learning-data-science-analytics-columbiax-ds102x-0)| 5 weeks | 7-10 hours/week
 [Big Data Science with the BD2K-LINCS Data Coordination and Integration Center](https://www.coursera.org/course/bd2klincs)| 7 weeks | 4-5 hours/week
+[Full Stack Open - Web Development](https://fullstackopen.com/en/)| 13 weeks | 15-20 hours 
 
 ## Tools
 


### PR DESCRIPTION
I noticed there is no course specialized in web development. Therefore, I suggest to add this great MOOC which is made open by University of Helsinki, and that covers modern web technologies.

> The course is worth 5-13 credits, and the content is the same as in the [Full stack course](https://fullstack-hy2020.github.io/) held at the [Department of Computer Science](https://www.helsinki.fi/en/computer-science) at the University of Helsinki in Spring 2020. There is also an associated [project](https://fullstackopen.com/osa0/yleista#full-stack-harjoitustyo) that is worth 1-10 credits.

https://fullstackopen.com/en/about

Features:
- It is an open source course: https://github.com/fullstack-hy2020/fullstack-hy2020.github.io
- It is annually updated
- It has a built-in assignment submission system based on GitHub
- Large community of students 

I added it to extra, under _Application_ section