### PR TITLE
Add IBM Cybersecurity Analyst Professional Certificate to the Final Project section

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Courses | Duration | Effort | Prerequisites
 [Data Science (Specialization)](https://www.coursera.org/specializations/jhu-data-science) | 43 weeks | 1-6 hours/week | none
 [Functional Programming in Scala (Specialization)](https://www.coursera.org/specializations/scala) | 29 weeks | 4-5 hours/week | One year programming experience
 [Game Design and Development with Unity 2020 (Specialization)](https://www.coursera.org/specializations/game-design-and-development) | 6 months | 5 hours/week | programming, interactive design
+[IBM Cybersecurity Analyst Professional Certificate](https://www.coursera.org/professional-certificates/ibm-cybersecurity-analyst) | 6 months | 6 hours/week | none
 
 ### Evaluation
 


### PR DESCRIPTION
I see that there is a thread containing discussion on the inclusion of cybersecurity resources #639. That repository has remained quiet for some time, but the field is continuing to grow in importance at a seemingly exceptional rate. I therefore think it should be an option to engage in a security related specialisation at the end of the OSSU.

See the specialisation home page here: https://www.coursera.org/professional-certificates/ibm-cybersecurity-analyst

**Overview**
- The specialisation is comprised of 8 courses, with a capstone and assessment at the end, much like the other specialisations listed in the 'Final Project' section.
- High quality teachers and recognised cybersecurity giant backing.
- Wide range of of areas covered including an introduction, operational security, sysadmin, networking, threat assessment, database security and incident response. 
- Highly rated curriculum (4.5 stars minimum course rating - capstone project rated at 4.8 stars). Ratings are a representation of over 60,000 students enrolled on the course (with approximately 5700 ratings). 
- Course material is up to date.
- The recommended completion time is in keeping with the other courses in this section.
- English, Arabic, French, Portuguese (European), Italian, Vietnamese, German, Russian, Spanish subtitles.
- The course is available to enrol for free.
- The course is appropriately challenging and in keeping with the other courses in this section. The course starts out with a 'beginner' rated introduction and progresses to 'intermediate' difficulty by the end.

**Considerations**
- There are some complaints about the audio quality on the videos. I would say that, although it is not perfect quality, it is perfectly audible and not at all difficult to understand or grating to listen to. In any case, the content of the video lectures is thorough and I personally feel that the course is taught in a clear, concise and easy to understand way.
- Adding a cybersecurity related course to the Final Projects section may not be appropriate since the other cybersecurity sections of the readme note that their inclusion is provisional pending further consideration. Notwithstanding, it is clear that more and more traditional brick and mortar universities are putting a greater and greater emphasis on cybersecurity in their curriculum's and it would be prudent to mirror that behaviour.
- Since the courses are taught by IBM, there is naturally discussion of some of the tools IBM offers, though this does not detract from the quality delivery of the subject matter and how best to approach various cybersecurity challanges. Traditional open source cybersecurity tools are heavily utilised.

**Sundaries**
- If accepted, the course will need adding to the Trello board.

The OSSU is a fantastic resource and I am very grateful to have been able to take advantage of it. I believe it can only get better by embracing cybersecurity resources and adding them as a path for future students to take.  For many people the OSSU is their only option for getting a high quality, structured education in computer science and I think they should be given the option to engage deeper with cybersecurity.

^ The above said, I am no cybersecurity vetran and would certainly welcome the thoughts of those who are on IBM's offering. I have considered the contribution guidelines and this repository and hope that I have not missed anything obvious as to why this cannot be included. 