### PR TITLE
Alternative link for missing courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,7 @@ Courses | Duration | Effort | Prerequisites
 [Compilers](https://www.edx.org/course/compilers) | 9 weeks | 6-8 hours/week | none
 [Introduction to Haskell](https://www.seas.upenn.edu/~cis194/fall16/)| 14 weeks | - | -
 [Learn Prolog Now!](https://www.let.rug.nl/bos/lpn//lpnpage.php?pageid=online) ([alt](https://github.com/ossu/computer-science/files/6085884/lpn.pdf))*| 12 weeks | - | -
-[Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming
-[Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience
+[Software Analysis & Testing](https://www.udacity.com/course/software-analysis-testing--ud333)| 16 weeks | 4 hours/week | Python, programming experience
 
 (*) book by Blackburn, Bos, Striegnitz (compiled from [source](https://github.com/LearnPrologNow/lpn), redistributed under [CC license](https://creativecommons.org/licenses/by-sa/4.0/))
 


### PR DESCRIPTION
The two courses Software Testing and Software Debugging are not present in Udacity. 
Although the link works, the courses can't be accessed in the classroom.
Hence to fix this issue, I suggest we pick this course from Georgia Tech to replace the missing courses.