### PR TITLE
change Logic course

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Courses | Duration | Effort | Prerequisites | Discussion
 [Essence of Linear Algebra](https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab) | - | - | [high school math](FAQ.md#how-can-i-review-the-math-prerequisites) | [chat](https://discord.gg/m6wHbP6)
 [Linear Algebra](https://ocw.mit.edu/courses/mathematics/18-06sc-linear-algebra-fall-2011/) | 14 weeks | 12 hours/week | corequisite: Essence of Linear Algebra | [chat](https://discord.gg/k7nSWJH)
 [Introduction to Numerical Methods](https://ocw.mit.edu/courses/mathematics/18-335j-introduction-to-numerical-methods-spring-2019/index.htm)| 14 weeks | 12 hours/week | [Linear Algebra](https://ocw.mit.edu/courses/mathematics/18-06sc-linear-algebra-fall-2011/) | [chat](https://discord.gg/FNEcNNq)
-[Introduction to Logic](https://www.coursera.org/learn/logic-introduction) | 10 weeks | 4-8 hours/week | [set theory](https://www.youtube.com/playlist?list=PL5KkMZvBpo5AH_5GpxMiryJT6Dkj32H6N) | [chat](https://discord.gg/MbM2Gg5)
+[Introduction to Formal Logic](https://forallx.openlogicproject.org/) | 10 weeks | 4-8 hours/week | [set theory](https://www.youtube.com/playlist?list=PL5KkMZvBpo5AH_5GpxMiryJT6Dkj32H6N) | [chat](https://discord.gg/MbM2Gg5)
 [Probability](https://projects.iq.harvard.edu/stat110/home) | 24 weeks | 12 hours/week | [Differentiation and Integration](https://www.edx.org/course/calculus-1b-integration) | [chat](https://discord.gg/UVjs9BU)
 
 ## Final project


### PR DESCRIPTION
The Stanford Introduction to Logic course on Coursera is broken.

Almost all of the external links
![Screenshot from 2022-09-09 15-46-15](https://user-images.githubusercontent.com/4255997/189353676-4e3db6cc-32cb-44d1-a90b-10cf404009c0.png)

end up dead:
![Screenshot from 2022-09-09 15-46-06](https://user-images.githubusercontent.com/4255997/189353745-4967887e-4716-4598-be26-a1505968cfc2.png)

It's been like this for about a year, and many learners left comments on Coursera discussion forums including myself, but they aren't fixing it.

So let's replace it with the [ForallX project](https://forallx.openlogicproject.org/) instead.

I did not open an RFC issue for this. Even though a course is being replaced, I do not consider this to be a significant change to the Curriculum. Almost the same, or equivalent, material is covered in the courses. Moreover a discussion was already held in [ossu/math](https://github.com/ossu/math/issues/9).

However, if you deem it necessary I'm fine with opening an RFC.