### PR TITLE
update How to Design Programs textbook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,9 @@ All coursework under Core CS is **required**, unless otherwise indicated.
 `Ruby`
 `and more`
 
-The How to Code courses are based on the textbook [How to Design Programs](https://htdp.org/2003-09-26/). The First Edition is available for free online and includes problem sets and solutions. Students are encouraged to do these assignments.
-
 Courses | Duration | Effort | Prerequisites | Discussion
 :-- | :--: | :--: | :--: | :--:
-[How to Code - Simple Data](https://www.edx.org/course/how-to-code-simple-data) | 7 weeks | 8-10 hours/week | none | [chat](https://discord.gg/RfqAmGJ)
+[How to Code - Simple Data](https://www.edx.org/course/how-to-code-simple-data) [(textbook)](https://htdp.org/2022-8-7/Book/index.html) | 7 weeks | 8-10 hours/week | none | [chat](https://discord.gg/RfqAmGJ)
 [How to Code - Complex Data](https://www.edx.org/course/how-to-code-complex-data) | 6 weeks | 8-10 hours/week | How to Code: Simple Data | [chat](https://discord.gg/kczJzpm)
 [Programming Languages, Part A](https://www.coursera.org/learn/programming-languages) | 5 weeks | 4-8 hours/week | How to Code ([Hear instructor](https://www.coursera.org/lecture/programming-languages/recommended-background-k1yuh)) | [chat](https://discord.gg/8BkJtXN)
 [Programming Languages, Part B](https://www.coursera.org/learn/programming-languages-part-b) | 3 weeks | 4-8 hours/week | Programming Languages, Part A | [chat](https://discord.gg/EeA7VR9)


### PR DESCRIPTION
Frequently we get confused learners who mention that the first edition of the textbook does not match the online edX courses, asking what they should do.

They are correct, the first edition does not match the courses. It's completely different in its organization. First edition authors agree:
![Screenshot from 2022-11-22 10-09-50](https://user-images.githubusercontent.com/4255997/203248340-887c391e-63ee-4486-83e0-ba2b37961d44.png)

The second edition on the other hand, matches the courses perfectly.

Not to mention, there are *a lot* of missing solutions in the first edition. We reported or even emailed some missing solutions to the authors but they clearly do not maintain the first edition anymore, it's there for archival purposes.

Currently our emphasis is to encourage learners to solve all of the Problem Bank on edX, which has solutions to everything. The fact that the second edition of the textbook does not have solutions is not a detraction in any way.