### PR TITLE
Move space between badges out of link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 </p>
 <p align="center">
   <a href="https://github.com/sindresorhus/awesome">
-    <img alt="Awesome" src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg">
-  </a>
+    <img alt="Awesome" src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg"
+  ></a>
   <a href="https://github.com/ossu/computer-science">
-	<img alt="Open Source Society University - Computer Science" src="https://img.shields.io/badge/OSSU-computer--science-blue.svg">
-  </a>
+    <img alt="Open Source Society University - Computer Science" src="https://img.shields.io/badge/OSSU-computer--science-blue.svg"
+  ></a>
 </p>
 
 # Contents


### PR DESCRIPTION
Before
![image](https://github.com/muzimuzhi/ossu-computer-science/assets/6376638/2eb64e03-6da2-4d6b-abd6-e60cd3f7e43c)
Note the wired short underlines in between badges.

After
![image](https://github.com/muzimuzhi/ossu-computer-science/assets/6376638/de928bf3-4ad3-4026-bdba-66a8efa9daa1)

Similar to https://github.com/typst/typst/pull/2866.
