### PR TITLE
Adding a new URL course for Git and GitHub because the old link invalid

### DIFF
--- a/extras/courses.md
+++ b/extras/courses.md
@@ -90,7 +90,7 @@ Courses | Duration | Effort
 
 Courses | Duration | Effort
 :-- | :--: | :--:
-[How to Use Git and GitHub](https://www.udacity.com/course/how-to-use-git-and-github--ud775) | 3 weeks | 2-3 hours/week
+[How to Use Git and GitHub](https://www.udacity.com/blog/2015/06/a-beginners-git-github-tutorial.html) | 3 weeks | 2-3 hours/week
 [Kubernetes Certified Application Developer](https://www.udemy.com/course/certified-kubernetes-application-developer/) | 5 weeks | 2 hours/week
 
 


### PR DESCRIPTION
When I went through the extra courses I went to the git and GitHub courses on the Udacity website i saw the link was invalid and didn't work, so I put the new link for the same course on the same website but another course.