### PR TITLE
Add Intro CS coursepage and replace the OCW version with an archived version on Edx

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This course will introduce you to the world of computer science. Students who ha
 
 Courses | Duration | Effort | Prerequisites | Discussion
 :-- | :--: | :--: | :--: | :--:
-[Introduction to Computer Science and Programming using Python](https://ocw.mit.edu/courses/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016/) ([alternative](https://www.edx.org/course/introduction-to-computer-science-and-programming-7)) | 9 weeks | 15 hours/week | [high school algebra](https://www.khanacademy.org/math/algebra-home) | [chat](https://discord.gg/jvchSm9)
+[Introduction to Computer Science and Programming using Python](coursepages/intro-cs/README.md) | 9 weeks | 15 hours/week | [high school algebra](https://www.khanacademy.org/math/algebra-home) | [chat](https://discord.gg/jvchSm9)
 
 ## Core CS
 

--- a/coursepages/intro-cs/README.md
+++ b/coursepages/intro-cs/README.md
@@ -1,0 +1,32 @@
+# Introduction to Computer Science
+
+This course will introduce you to the world of computer science. Students who have been introduced to programming, either from the courses above or through study elsewhere, should take this course for a flavor of the material to come. If you finish the course wanting more, Computer Science is likely for you!
+
+This course has been developed by MIT and is available from three different places. We recommend you to do it from the archived version on Edx.
+
+> 6.0001 Introduction to Computer Science and Programming in Python is intended for students with little or no programming experience. It aims to provide students with an understanding of the role computation can play in solving problems and to help students, regardless of their major, feel justifiably confident of their ability to write small programs that allow them to accomplish useful goals. The class uses the Python 3.5 programming language.
+
+**Course Link:** https://learning.edx.org/course/course-v1:MITx+6.00.1x+2T2018/home
+
+Alternative Links:
+
+- https://ocw.mit.edu/courses/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016/
+- https://www.edx.org/course/introduction-to-computer-science-and-programming-7 (instructor-paced version, runs three times a year)
+
+## Instructions
+
+**Note:** These instructions are for the archived version of the course on Edx, which we recommend. They don't apply to other versions of the course.
+
+- The course does not have a homepage on Edx, but don't worry about it. Open the [link](https://learning.edx.org/course/course-v1:MITx+6.00.1x+2T2018/home) given above, log in (if you are not logged in) and then enroll in the course.
+- Work through the course as given in the course overview. Watch the videos, do the finger exercises, and then solve the problem sets.
+- You won't be able to submit your responses for the finger exercises, but you can see their answers by clicking on "Show Answer". Check your answers honestly.
+- You won't be able to submit the problem sets on their own page. To submit them, go to the "Sandbox" section (It is the last section. You can find it on the course overview). There, you will be able to submit your work and get it graded.
+- You don't need to install the full Anaconda distribution to do this course. See the notes section below for more information.
+- If you are stuck somewhere, feel free to ask questions. You can join the OSSU chat for this course here: https://discord.gg/jvchSm9.
+
+## Notes
+
+- You don't need to install the full anaconda package to do this course. You can just download the Spyder IDE from here: https://github.com/spyder-ide/spyder/releases/latest. It comes bundles with python as well as some popular scientific python libraries (all the libraries which this course uses are included), but it is not as large or complex as the full anaconda distribution. You don't need to set up python separately or anything.
+- The community has found this resource useful: https://www.youtube.com/playlist?list=PL4e66Kzl1JCFPVBa7gBzWJF_FDF3KBf-2
+- You won't get any certificate for doing this course. If you really want a certificate, you need to do the [instructor-paced version of this course](https://www.edx.org/course/introduction-to-computer-science-and-programming-7) on Edx. Certificate of an introductory course like this is not very valuable, so unless you are absolutely sure, we recommend you to do the archived version of this course instead.
+- If for some reason you want to do the OCW version of the course, you will find many useful notes and fixes of various problems in our [discord server](https://discord.gg/jvchSm9).

--- a/coursepages/intro-cs/README.md
+++ b/coursepages/intro-cs/README.md
@@ -6,12 +6,12 @@ This course has been developed by MIT and is available from three different plac
 
 > 6.0001 Introduction to Computer Science and Programming in Python is intended for students with little or no programming experience. It aims to provide students with an understanding of the role computation can play in solving problems and to help students, regardless of their major, feel justifiably confident of their ability to write small programs that allow them to accomplish useful goals. The class uses the Python 3.5 programming language.
 
-**Course Link:** https://learning.edx.org/course/course-v1:MITx+6.00.1x+2T2018/home
+**Course Link:** <https://learning.edx.org/course/course-v1:MITx+6.00.1x+2T2018/home>
 
 Alternative Links:
 
-- https://ocw.mit.edu/courses/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016/
-- https://www.edx.org/course/introduction-to-computer-science-and-programming-7 (instructor-paced version, runs three times a year)
+- <https://ocw.mit.edu/courses/6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016/>
+- <https://www.edx.org/course/introduction-to-computer-science-and-programming-7> (instructor-paced version, runs three times a year)
 
 ## Instructions
 
@@ -22,11 +22,11 @@ Alternative Links:
 - You won't be able to submit your responses for the finger exercises, but you can see their answers by clicking on "Show Answer". Check your answers honestly.
 - You won't be able to submit the problem sets on their own page. To submit them, go to the "Sandbox" section (It is the last section. You can find it on the course overview). There, you will be able to submit your work and get it graded.
 - You don't need to install the full Anaconda distribution to do this course. See the notes section below for more information.
-- If you are stuck somewhere, feel free to ask questions. You can join the OSSU chat for this course here: https://discord.gg/jvchSm9.
+- If you are stuck somewhere, feel free to ask questions. You can join the OSSU chat for this course here: <https://discord.gg/jvchSm9>.
 
 ## Notes
 
-- You don't need to install the full anaconda package to do this course. You can just download the Spyder IDE from here: https://github.com/spyder-ide/spyder/releases/latest. It comes bundles with python as well as some popular scientific python libraries (all the libraries which this course uses are included), but it is not as large or complex as the full anaconda distribution. You don't need to set up python separately or anything.
-- The community has found this resource useful: https://www.youtube.com/playlist?list=PL4e66Kzl1JCFPVBa7gBzWJF_FDF3KBf-2
+- You don't need to install the full anaconda package to do this course. You can just download the Spyder IDE from here: <https://github.com/spyder-ide/spyder/releases/latest>. It comes bundles with python as well as some popular scientific python libraries (all the libraries which this course uses are included), but it is not as large or complex as the full anaconda distribution. You don't need to set up python separately or anything.
+- The community has found this resource useful: <https://www.youtube.com/playlist?list=PL4e66Kzl1JCFPVBa7gBzWJF_FDF3KBf-2>
 - You won't get any certificate for doing this course. If you really want a certificate, you need to do the [instructor-paced version of this course](https://www.edx.org/course/introduction-to-computer-science-and-programming-7) on Edx. Certificate of an introductory course like this is not very valuable, so unless you are absolutely sure, we recommend you to do the archived version of this course instead.
 - If for some reason you want to do the OCW version of the course, you will find many useful notes and fixes of various problems in our [discord server](https://discord.gg/jvchSm9).


### PR DESCRIPTION
Similar to #1176, a discord community member (satoshiriraagus) found an archived version of the MIT Intro CS course on Edx: https://learning.edx.org/course/course-v1:MITx+6.00.1x+2T2018/home

The OCW version is showing its age, and several problems are appearing with its content. IMO, the Edx version is much better, as it is newer (though it still uses python 3.5), it has much more finger exercises than the Edx version, and the biggest benefit: it has autograders which evaluate your code, unlike the OCW version.

Now, since the Edx version runs only three times a year and is instructor paced, it is not really suitable to be included as the default recommendation. That is where the archived Edx version comes. It is archived, so all the contents are available at once. It has no deadlines and is completely self-paced. So all in all, it has all the benefits of the Edx version, and none of its issues.

I have also made a coursepage for the course, to help people smoothly do the course.