### PR TITLE
Add page title in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+title: Computer Science


### PR DESCRIPTION
Added a page title in _config.yml file. It is used in the website generated using Github pages.

I also suggest that the emoji syntax from the about section of OSSU repositories should be removed, or replaced with unicode emoji. While the syntax is rendered correctly on the page, it causes this in the page title: 

![image](https://github.com/ossu/computer-science/assets/72264063/a381b8f8-e221-43bc-ad66-8e4e5b4d71ee)

The difference in website before and after this PR and the above suggestion is implemented (notice the page title in the tab too):

Before: 
![Screenshot_20240609_122550](https://github.com/ossu/computer-science/assets/72264063/a135781e-c95f-4fa8-8b47-a1595f2d8901)

After:
![Screenshot_20240609_122630](https://github.com/ossu/computer-science/assets/72264063/5b6a6308-b7a3-480c-b70f-12341c3d53fb)
