### PR TITLE
Make the high school algebra (Intro CS prerequisite) link consistent …

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This course will introduce you to the world of computer science and programming.
 
 Courses | Duration | Effort | Prerequisites | Discussion
 :-- | :--: | :--: | :--: | :--:
-[Introduction to Computer Science and Programming using Python](coursepages/intro-cs/README.md) | 14 weeks | 6-10 hours/week | [high school algebra](https://www.khanacademy.org/math/algebra-home) | [chat](https://discord.gg/jvchSm9)
+[Introduction to Computer Science and Programming using Python](coursepages/intro-cs/README.md) | 14 weeks | 6-10 hours/week | [high school algebra](FAQ.md#how-can-i-review-the-math-prerequisites) | [chat](https://discord.gg/jvchSm9)
 
 ## Core CS
 


### PR DESCRIPTION
…with the FAQ

Change the link in the prerequisite column of the Intro CS course to point to the FAQ about high school math, and not to Khan academy, to keep things consistent