### PR TITLE
Remove a duplicate entry of How to Design Programs (2nd ed.)

### DIFF
--- a/extras/readings.md
+++ b/extras/readings.md
@@ -26,7 +26,6 @@ Name | Author(s)
 [Programming and Programming Languages](https://papl.cs.brown.edu/2018/) | Shriram Krishnamurthi, Benjamin S. Lerner, Joe Gibbs Politz
 [Competitive Programming](https://cpbook.net/) | Steven Halim, Felix Halim
 [Introduction to computing in Java](https://introcs.cs.princeton.edu/java/home/) | Robert Sedgewick, Kevin Wayne
-[How to Design Programs, Second Edition](https://htdp.org/2023-8-14/Book/index.html) | Matthias Felleisen, Robert Bruce Findler, Matthew Flatt, Shriram Krishnamurthi
 
 ## Math
 


### PR DESCRIPTION
Hello everyone,

It seems that there is a duplicate entry for the book How to Design Programs (2nd ed.) in the extra readings list, programming section.

The third entry in that section already includes this book, using a permalink rather than linking to a specific version.

The current version of the book is dated November 6, 2024, which also makes the duplicate entry slightly outdated.

Thank you for taking a look.

Best regards,